### PR TITLE
Enable Authentication Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ public class MainActivity extends FirebaseLoginBaseActivity {
     protected void onStart() {
         super.onStart();
         // All providers are optional! Remove any you don't want.
-        setEnabledAuthProvider(AuthProviderType.FACEBOOK);
-        setEnabledAuthProvider(AuthProviderType.TWITTER);
-        setEnabledAuthProvider(AuthProviderType.GOOGLE);
-        setEnabledAuthProvider(AuthProviderType.PASSWORD);
+        setEnabledAuthProvider(SocialProvider.facebook);
+        setEnabledAuthProvider(SocialProvider.twitter);
+        setEnabledAuthProvider(SocialProvider.google);
+        setEnabledAuthProvider(SocialProvider.password);
     }
 ```
 


### PR DESCRIPTION
In the code example to Enable Authentication Providers. 
Instead of calling AuthProvider.Facebook , you should use SocialProvider.facebook.

I discovered this syntax error when trying to follow the readme
